### PR TITLE
Add option to sents2elmo to return all layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ def sents2elmo(sents, output_layer=-1):
     -  1 for the first LSTM hidden layer
     -  2 for the second LSTM hidden layer
     -  -1 for an average of 3 layers. (default)
+    -  -2 for all 3 layers
 
 ## Training Your Own ELMo
 

--- a/elmoformanylangs/elmo.py
+++ b/elmoformanylangs/elmo.py
@@ -200,6 +200,8 @@ class Embedder(object):
 
                 if output_layer == -1:
                     payload = np.average(data, axis=0)
+                elif output_layer == -2:
+                    payload = data[0:3]
                 else:
                     payload = data[output_layer]
                 after_elmo.append(payload)

--- a/elmoformanylangs/elmo.py
+++ b/elmoformanylangs/elmo.py
@@ -201,7 +201,7 @@ class Embedder(object):
                 if output_layer == -1:
                     payload = np.average(data, axis=0)
                 elif output_layer == -2:
-                    payload = data[0:3]
+                    payload = data
                 else:
                     payload = data[output_layer]
                 after_elmo.append(payload)


### PR DESCRIPTION
This PR adds the option to return all ELMo layers by calling `sents2elmo` with `output_layer=-2`, and updates the readme accordingly.