### PR TITLE
fix: disable signature check in override

### DIFF
--- a/elmoformanylangs/modules/highway.py
+++ b/elmoformanylangs/modules/highway.py
@@ -43,7 +43,7 @@ class Highway(torch.nn.Module):
             # of the bias vector in each Linear layer.
             layer.bias[input_dim:].data.fill_(1)
 
-    @overrides
+    @overrides(check_signature=False)
     def forward(self, inputs: torch.Tensor) -> torch.Tensor:  # pylint: disable=arguments-differ
         current_input = inputs
         for layer in self._layers:


### PR DESCRIPTION
With the addition of signature checks in `override v5.0.0` (https://github.com/mkorpela/overrides/releases/tag/5.0.0), importing the `ELMoForManyLangs` package will fail as mentioned in issue #95. I propose a simple fix by simply disabling the signature check.